### PR TITLE
Updated monkeytype url

### DIFF
--- a/monkey-type.ipynb
+++ b/monkey-type.ipynb
@@ -144,7 +144,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url = 'https://monkey-type.com/'\n",
+    "url = 'https://monkeytype.com/'\n",
     "browser.get(url)"
    ]
   },


### PR DESCRIPTION
updated the monkeytype url to the new domain monkeytype.com